### PR TITLE
build: update go version to 1.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+/vendor

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/qustavo/dotsql
 
-go 1.12
+go 1.18
 
 require github.com/mxk/go-sqlite v0.0.0-20140611214908-167da9432e1f


### PR DESCRIPTION
Hey 

I just noticed the go version was in 1.12 and this PR updates it to 1.18, let me know if that's ok.

Thanks